### PR TITLE
Windows Onboarding

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -6,5 +6,8 @@ STRIPE_PUBLIC=pk_test_51HERaHFHEvC1s7vkxMfTOWuGCHWCyukcRbwF5WNOUgeWWkAUHj2btlzxG
 
 # Request the following values from support
 # CLERK_SECRET_KEY
-# STRIPE_SECRET
+# STRIPE_SECRET_KEY
 # STRIPE_WEBHOOK_SECRET
+
+# Uncomment the following line to enable debug logging
+# DEBUG=api,sendmessage

--- a/.env.default
+++ b/.env.default
@@ -8,6 +8,3 @@ STRIPE_PUBLIC=pk_test_51HERaHFHEvC1s7vkxMfTOWuGCHWCyukcRbwF5WNOUgeWWkAUHj2btlzxG
 # CLERK_SECRET_KEY
 # STRIPE_SECRET_KEY
 # STRIPE_WEBHOOK_SECRET
-
-# Uncomment the following line to enable debug logging
-# DEBUG=api,sendmessage

--- a/data/compareSqlSchemas.ts
+++ b/data/compareSqlSchemas.ts
@@ -6,7 +6,7 @@ const compareSqlSchemas = async () => {
   const OUT_DIR = path.join("out", "migrations");
   if (fs.existsSync(OUT_DIR)) fs.rmSync(OUT_DIR, { recursive: true });
   execSync(
-    `npx drizzle-kit introspect:mysql --out ${OUT_DIR} --connectionString='${process.env.DATABASE_URL}'`,
+    `npx drizzle-kit introspect:mysql --out ${OUT_DIR} --connectionString="${process.env.DATABASE_URL}"`,
     { stdio: "inherit" }
   );
   execSync(

--- a/docs/developer/how_to_contribute.md
+++ b/docs/developer/how_to_contribute.md
@@ -42,8 +42,9 @@ The following directories also exist but are expected to be temporary:
    1. Create Database: `CREATE DATABASE samepage_network;`
    2. Create User: `CREATE USER 'samepage_network'@'localhost' IDENTIFIED BY 'samepage_network';`
    3. Grant Privileges: `GRANT ALL PRIVILEGES ON samepage_network.* TO 'samepage_network'@'localhost';`
-1. Apply the SamePage schema to your local `mysql` instance by running `npx ts-node scripts/cli.ts plan --sql`, followed by `npx ts-node scripts/cli.ts apply --sql --bare`.
+1. Apply the SamePage database schema to your local `mysql` instance by running `npx ts-node scripts/cli.ts plan --sql`, followed by `npx ts-node scripts/cli.ts apply --sql --bare`.
 1. `npm start` to run the app.
+1. Debugging: we use `debug` to help with debugging. See its [NPM package documentation](https://www.npmjs.com/package/debug) for usage details.
 
 ### Contributing
 

--- a/docs/developer/how_to_contribute.md
+++ b/docs/developer/how_to_contribute.md
@@ -13,18 +13,20 @@ This is our main [monorepo](https://github.com/samepage-network/samepage.network
 
 ### Architecture
 
-The repository contains several top level directories that roughly correspond to a separate _deployment target_. Each deployment target has a github action in the `.github/workflows` directory that watches for changes in the corresponding directory on the `main` branch and runs its deployment when it does. 
+The repository contains several top level directories that roughly correspond to a separate _deployment target_. Each deployment target has a github action in the `.github/workflows` directory that watches for changes in the corresponding directory on the `main` branch and runs its deployment when it does.
 
 The top level directories are as follows:
+
 - `api` - Each file in this directory represents an [AWS Lambda](https://aws.amazon.com/lambda/) function deployed to our [API gateway](https://aws.amazon.com/api-gateway/). The files within the `ws` subdirectory are deployed to our WebSocket Gateway.
 - `app` - The files contained in this directory make up the [Remix](https://remix.run) web application.
-- `data` - Defines our SQL and infrastructure schema in a declarative format, using [Zod](https://zod.dev) and the [CDK for Terraform](https://www.terraform.io/cdktf). 
+- `data` - Defines our SQL and infrastructure schema in a declarative format, using [Zod](https://zod.dev) and the [CDK for Terraform](https://www.terraform.io/cdktf).
 - `package` - Defines all of the packages that we publish to `npm`, to be used by extensions for each supported tool for thought. The entire directory is published as a single `samepage` package, as well as individual `@samepage` scoped packages.
 - `scripts` - One off scripts that are run within CI and locally to help serve the developer experience for SamePage.
 - `template` - Directory we use to generate each additional extension repo.
 - `tests` - The suite of tests to protect against regression on our network or packages. Patterns and conventions around testing are still under active development.
 
 The following directories also exist but are expected to be temporary:
+
 - `docs` & `public` - Hosts the static content used by `app`. Expected to migrate into that directory.
 - `patches` - Changes made to dependent node modules that we should push upstream to improve the libraries we use.
 
@@ -34,9 +36,13 @@ The following directories also exist but are expected to be temporary:
 1. Clone the repository locally.
 1. Install dependencies with `npm install`.
 1. Copy the `.env.default` file to `.env`, and replace the values that are marked `TODO`
-    1. `CLERK_API_KEY` - Get from `@dvargas92495`
-1. Ensure you have a local instance of `mysql` running, with a user with username and password both with the value `samepage_network`, running on port 3306, and a database created called `mysql`.
-1. Apply the SamePage schema to your local `mysql` instance by running `npx ts-node scripts/cli.ts plan --sql`, followed by `npx ts-node scripts/cli.ts apply --sql`.
+   1. `CLERK_SECRET_KEY` - Get from `@dvargas92495`
+   2. `STRIPE_SECRET_KEY` - Get from `@dvargas92495`
+1. Ensure you have a local instance of `mysql` running, with a user with username and password both with the value `samepage_network`, running on port 3306, and a database created called `samepage_network`.
+   1. Create Database: `CREATE DATABASE samepage_network;`
+   2. Create User: `CREATE USER 'samepage_network'@'localhost' IDENTIFIED BY 'samepage_network';`
+   3. Grant Privileges: `GRANT ALL PRIVILEGES ON samepage_network.* TO 'samepage_network'@'localhost';`
+1. Apply the SamePage schema to your local `mysql` instance by running `npx ts-node scripts/cli.ts plan --sql`, followed by `npx ts-node scripts/cli.ts apply --sql --bare`.
 1. `npm start` to run the app.
 
 ### Contributing
@@ -49,6 +55,7 @@ The following directories also exist but are expected to be temporary:
 ## `[tool]`
 
 For each tool for thought that we support, we have a separate repository hosting the code for its extension. We currently support the following clients:
+
 - [Roam](https://github.com/dvargas92495/roamjs-samepage)
 - [LogSeq](https://github.com/dvargas92495/logseq-samepage)
 - [Obsidian](https://github.com/dvargas92495/obsidian-samepage)

--- a/scripts/commands/api.ts
+++ b/scripts/commands/api.ts
@@ -14,6 +14,7 @@ import debugMod from "../../package/utils/debugger";
 import fs from "fs";
 import crypto from "crypto";
 import { qsToJson } from "../../package/backend/createAPIGatewayProxyHandler";
+import * as dirPath from "path";
 
 const debug = debugMod("api");
 const METHODS = ["get", "post", "put", "delete", "options"] as const;
@@ -477,7 +478,9 @@ const api = async ({ local }: { local?: boolean } = {}): Promise<number> => {
         debug("new message from", connectionId);
         const body = data.toString();
         const action = JSON.parse(body).action;
-        const filePath = wsEntries.find((f) => f.endsWith(`/ws/${action}`));
+        const filePath = wsEntries.find((f) =>
+          f.endsWith(dirPath.join("ws", action))
+        );
         if (filePath) {
           import(filePath).then(({ handler }) => {
             delete require.cache[filePath];
@@ -494,7 +497,9 @@ const api = async ({ local }: { local?: boolean } = {}): Promise<number> => {
       ws.on("close", (a: number, b: Buffer) => {
         debug("client closing...", a, b.toString());
         removeLocalSocket(connectionId);
-        const filePath = wsEntries.find((f) => f.endsWith(`/ws/ondisconnect`));
+        const filePath = wsEntries.find((f) =>
+          f.endsWith(dirPath.join("ws", "ondisconnect"))
+        );
         if (filePath) {
           import(filePath).then(({ handler }) => {
             delete require.cache[filePath];
@@ -509,7 +514,9 @@ const api = async ({ local }: { local?: boolean } = {}): Promise<number> => {
         }
       });
       addLocalSocket(connectionId, ws);
-      const filePath = wsEntries.find((f) => f.endsWith(`/ws/onconnect`));
+      const filePath = wsEntries.find((f) =>
+        f.endsWith(dirPath.join("ws", "onconnect"))
+      );
       if (filePath) {
         import(filePath).then(({ handler }) => {
           delete require.cache[filePath];

--- a/scripts/commands/dev.ts
+++ b/scripts/commands/dev.ts
@@ -1,17 +1,22 @@
 import { dev as remixDev } from "@remix-run/dev/dist/cli/commands";
 import { spawn } from "child_process";
 import ngrok from "ngrok";
+import os from "os";
+
+const shell = os.platform() === "win32";
 
 type FeArgs = { port?: string; local?: boolean };
 
 const dev = async (args: FeArgs = {}): Promise<number> => {
   process.env.NODE_ENV = process.env.NODE_ENV || "development";
-  process.env.OCTOKIT_URL = process.env.OCTOKIT_URL || "http://localhost:3003/mocks/octokit";
+  process.env.OCTOKIT_URL =
+    process.env.OCTOKIT_URL || "http://localhost:3003/mocks/octokit";
   if (args.port) process.env.PORT = args.port;
 
   // TODO - Future versions of Remix have native Tailwind support
   spawn("npx", ["tailwindcss", "-o", "./app/tailwind.css", "--watch"], {
     stdio: "inherit",
+    shell,
   });
 
   if (!args.local) {


### PR DESCRIPTION
Left out creating a user token and apps table seed

`token`
>We have a webhook on Clerk that assigns a user a token whenever a new one is created. That webhook did not hit your local endpoint bc it's set up to hit mine. I'll have to think through what a proper workaround here is (my first thought is to start setting up clerk in /mocks), but in the meantime, you could look at the code in /api/user/post.ts to see how to manually give yourself a token.

```
        getMysql().then((cxn) =>
          cxn
            .select({
              count: sql`COUNT(uuid)`,
            })
            .from(tokens)
            .where(eq(tokens.userId, userId))
            .then(async ([a]) =>
              !a?.count
                ? await cxn.insert(tokens).values({
                    uuid: v4(),
                    value: await randomString({
                      length: 12,
                      encoding: "base64",
                    }),
                    createdDate: new Date(),
                    userId,
                  })
                : Promise.resolve()
            )
            .then(() => cxn.end())
        );
```

`seed`
>So we're also going to need to seed your database with records in the apps table. I should create a script to make this easier. Try running:
```
INSERT INTO samepage_network.apps (id, code, name, workspace_label, live) VALUES (1, 'roam', 'Roam', 'graph', false)
```

