### PR TITLE
Adding agent bootstrap script

### DIFF
--- a/app/server/index.ts
+++ b/app/server/index.ts
@@ -22,6 +22,7 @@ export const handler = createRequestHandler({
     /^\/images\/.*/,
     /^\/pdfs\/.*/,
     /^\/releases\/.*/,
+    /^\/scripts\/.*/,
     /^\/svgs\/.*/,
     /^\/videos\/.*/,
     /^\/.well-known\/.*/,

--- a/data/main.ts
+++ b/data/main.ts
@@ -42,6 +42,7 @@ import { DataAwsIamPolicyDocument } from "@cdktf/provider-aws/lib/data-aws-iam-p
 import { DataAwsCallerIdentity } from "@cdktf/provider-aws/lib/data-aws-caller-identity";
 import { GithubProvider } from "@cdktf/provider-github/lib/provider";
 import { ActionsSecret } from "@cdktf/provider-github/lib/actions-secret";
+import { S3Object } from "@cdktf/provider-aws/lib/s3-object";
 import { S3Bucket } from "@cdktf/provider-aws/lib/s3-bucket";
 import { S3BucketWebsiteConfiguration } from "@cdktf/provider-aws/lib/s3-bucket-website-configuration";
 import { S3BucketCorsConfiguration } from "@cdktf/provider-aws/lib/s3-bucket-cors-configuration";
@@ -161,6 +162,12 @@ const setupInfrastructure = async (): Promise<void> => {
           bucket: buckets[projectName].id,
         }
       );
+
+      new S3Object(this, "main_boostrap_sh", {
+        bucket: mainWebsite.bucket,
+        key: "scripts/bootstrap.sh",
+        source: "./scripts/bootstrap.sh",
+      });
 
       new S3BucketCorsConfiguration(this, "main_cors", {
         bucket: buckets[projectName].id,

--- a/data/scripts/bootstrap.sh
+++ b/data/scripts/bootstrap.sh
@@ -1,0 +1,26 @@
+# This is the entrypoint script for an agent. It is responsible for setting up the agent on a fresh machine.
+# This file is hosted on SamePage. To run it for a new agent, simply run:
+# 
+# curl https://samepage.network/scripts/bootstrap.sh | sh
+# 
+
+# INSTALL GIT
+sudo apt install git-all
+
+# INSTALL GITHUB CLI
+# https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+sudo mkdir -p -m 755 /etc/apt/keyrings && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+&& sudo apt update \
+&& sudo apt install gh -y
+# Steps to automate:
+# ? What account do you want to log into? GitHub.com
+# ? What is your preferred protocol for Git operations on this host? HTTPS
+# ? Authenticate Git with your GitHub credentials? Yes
+# ? How would you like to authenticate GitHub CLI? Paste an authentication token
+# ? Paste your authentication token: <token setup during onboarding>
+
+# CREATE WORKSPACE - This is where the agent will perform most of its work
+mkdir workspace
+cd workspace


### PR DESCRIPTION
Agents are going to essentially be ec2 instances. This is how we interact with other employees in our day to day - they are just other computers for all that we know.

There will be a lot more thought required for how to onboard any employee. This script starts to onboard a specific agent - an engineer that completes ticketed tasks. By honing in on this use case, we could start to learn the workflows it needs to perform its day-to-day, solving the onboarding problem in parallel.

The expected flow:
- dynamically create an aws ec2 instance
- run `curl https://samepage.network/scripts/bootstrap.sh | sh`