### PR TITLE
Add instance id column to employees table

### DIFF
--- a/data/schema.ts
+++ b/data/schema.ts
@@ -452,6 +452,7 @@ export const employees = mysqlTable("employees", {
   title: varchar("title", { length: 128 }).notNull().default(""),
   hiredDate: date("created"),
   config: employeeConfigColumn,
+  instanceId: varchar("instance_id", { length: 128 }).notNull().default(""),
 });
 
 export const employeesHistory = mysqlTable("employees_history", {
@@ -463,4 +464,5 @@ export const employeesHistory = mysqlTable("employees_history", {
   config: employeeConfigColumn,
   historyUser: varchar("history_user", { length: 128 }).notNull().default(""),
   historyDate: date("history_date"),
+  instanceId: varchar("instance_id", { length: 128 }).notNull().default(""),
 });


### PR DESCRIPTION
This will allow us to maintain a mapping between the employees we track in our database, and the agent box they are running on