### PR TITLE
Oauth Post install check

### DIFF
--- a/api/access-token/post.ts
+++ b/api/access-token/post.ts
@@ -1,0 +1,69 @@
+import { accessTokens } from "data/schema";
+import { eq } from "drizzle-orm/expressions";
+import createAPIGatewayProxyHandler from "package/backend/createAPIGatewayProxyHandler";
+import { BackendRequest } from "package/internal/types";
+import getMysql from "~/data/mysql.server";
+import { z } from "zod";
+import { UnauthorizedError } from "~/data/errors.server";
+import { MySql2Database } from "drizzle-orm/mysql2";
+import { MySqlColumn } from "drizzle-orm/mysql-core";
+
+const bodySchema = z.object({
+  code: z.string().optional(),
+  state: z.string().optional(),
+});
+
+type Column = {
+  data: string;
+  driverParam: string | number;
+  notNull: true;
+  hasDefault: true;
+  tableName: "access_tokens";
+};
+
+const fetchAccessToken = async (
+  cxn: MySql2Database,
+  field: MySqlColumn<Column>,
+  value: string
+) => {
+  const accessTokenByCode = await cxn
+    .select({ accessToken: accessTokens.value })
+    .from(accessTokens)
+    .where(eq(field, value));
+
+  if (!accessTokenByCode) {
+    throw new UnauthorizedError(
+      "No access token found for the provided identifier"
+    );
+  }
+
+  return accessTokenByCode[0]?.accessToken;
+};
+
+const logic = async (args: BackendRequest<typeof bodySchema>) => {
+  const cxn = await getMysql(args.requestId);
+
+  let returnedAccessToken;
+  if (args?.code) {
+    returnedAccessToken = await fetchAccessToken(
+      cxn,
+      accessTokens.code,
+      args.code
+    );
+  } else if (args?.state) {
+    returnedAccessToken = await fetchAccessToken(
+      cxn,
+      accessTokens.state,
+      args.state
+    );
+  }
+
+  await cxn.end();
+  return { accessToken: returnedAccessToken };
+};
+
+export default createAPIGatewayProxyHandler({
+  logic,
+  allowedOrigins: [/.*/],
+  bodySchema,
+});

--- a/app/routes/__public/oauth/$id.tsx
+++ b/app/routes/__public/oauth/$id.tsx
@@ -37,8 +37,8 @@ const OauthConnectionPage = (): React.ReactElement => {
             data: { state: data.state },
           }).then((r) => {
             if (r?.accessToken) {
-              setMessage("Success! This page will close.");
-              setTimeout(() => window.close(), 5000);
+              setMessage("Success! You may close this page.");
+              setTimeout(() => window.close(), 4000);
             } else {
               attemptAmount++;
               setTimeout(check, 1000);
@@ -46,7 +46,8 @@ const OauthConnectionPage = (): React.ReactElement => {
           });
         } else {
           setMessage(
-            "If using the app instead of the browser, please authorize in app.  Otherise please contact support."
+            `If you are using the app instead of the browser, please authorize in app.
+            Otherwise please contact support@samepage.network`
           );
         }
       };

--- a/app/routes/__public/oauth/$id.tsx
+++ b/app/routes/__public/oauth/$id.tsx
@@ -22,12 +22,10 @@ import { apiPost } from "package/internal/apiClient";
 const OauthConnectionPage = (): React.ReactElement => {
   const data = useLoaderData<typeof loadData>();
   const [message, setMessage] = useState<string>("Please Wait");
-  
   const postMessage = () => {
     if (window.opener && !window.opener.closed && "accessToken" in data) {
       window.opener.postMessage(data.accessToken, "*");
     }
-
     if ("state" in data) {
       let attemptAmount = 0;
       const check = () => {
@@ -220,7 +218,6 @@ const getAnonymousAccessToken = async ({
 }) => {
   const { id = "" } = params;
   const { code, installation_id, state, ...customParams } = searchParams;
-
   const cxn = await getMysql(requestId);
 
   const accessTokenByCode = await cxn

--- a/app/routes/__public/oauth/$id.tsx
+++ b/app/routes/__public/oauth/$id.tsx
@@ -38,7 +38,7 @@ const OauthConnectionPage = (): React.ReactElement => {
           }).then((r) => {
             if (r?.accessToken) {
               setMessage("Success! This page will close.");
-              setTimeout(() => window.close(), 10000);
+              setTimeout(() => window.close(), 5000);
             } else {
               attemptAmount++;
               setTimeout(check, 1000);

--- a/app/routes/__public/oauth/$id.tsx
+++ b/app/routes/__public/oauth/$id.tsx
@@ -34,12 +34,11 @@ const OauthConnectionPage = (): React.ReactElement => {
         if (attemptAmount < 10) {
           apiPost({
             path: "access-token",
-            domain: "https://api.samepage.ngrok.io",
             data: { state: data.state },
           }).then((r) => {
             if (r?.accessToken) {
               setMessage("Success! This page will close.");
-              setTimeout(() => window.close(), 1000);
+              setTimeout(() => window.close(), 10000);
             } else {
               attemptAmount++;
               setTimeout(check, 1000);
@@ -124,6 +123,7 @@ const loadData = async ({
 }) => {
   const { id = "" } = params;
   const { code, state, error, ...customParams } = searchParams;
+  console.log("loadData searchParams", searchParams);
   const cxn = await getMysql(requestId);
   const [app] = await cxn
     .select({ name: apps.name, id: apps.id })

--- a/app/routes/__public/oauth/$id.tsx
+++ b/app/routes/__public/oauth/$id.tsx
@@ -31,7 +31,7 @@ const OauthConnectionPage = (): React.ReactElement => {
     if ("state" in data) {
       let attemptAmount = 0;
       const check = () => {
-        if (attemptAmount < 10) {
+        if (attemptAmount < 30) {
           apiPost({
             path: "access-token",
             data: { state: data.state },

--- a/data/schema.ts
+++ b/data/schema.ts
@@ -311,6 +311,7 @@ export const accessTokens = mysqlTable(
       .notNull()
       .default(""),
     code: varchar("code", { length: 128 }).notNull().default(""),
+    state: varchar("state", { length: 128 }).notNull().default(""),
     createdDate: datetime("created_date")
       .notNull()
       .default(sql`(CURRENT_TIMESTAMP)`),


### PR DESCRIPTION
This PR sets up a `access-token` specific api endpoint to be called from `/oauth/{id}` and extensions.

This will be used when the extension doesn't allow for a popup window to pass a `postMessage` (eg: electron apps).

The extension will pass a `state` string via searchParams following this pattern:
https://github.com/RoamJS/roamjs-components/blob/main/src/components/ExternalLogin.tsx#L49

While this solves for the [GitHub Authorizing Oauth Apps](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps), it does not solve for when a user installs the GitHub App that has `Request user authorization (OAuth) during installation` toggled on, as the `state` isn't passed on.